### PR TITLE
fix: populate TorBox download URLs using requestdl redirect

### DIFF
--- a/pkg/torbox/downloads.go
+++ b/pkg/torbox/downloads.go
@@ -17,7 +17,9 @@ const linkExpiryDuration = 3 * time.Hour
 
 // GetDownloads builds a download list from completed torrents and their files.
 // Unlike Real-Debrid, TorBox doesn't have a separate "downloads" cache.
-// Instead, we build the download list from torrent files, requesting download URLs on demand.
+// We use the requestdl redirect URL as the download URL — media players hit it
+// and get redirected to the actual file. This avoids needing to pre-fetch URLs
+// that expire after ~3 hours.
 func (c *Client) GetDownloads(torrents []*Torrent) ([]*Download, error) {
 	c.logger.Debug().Msg("Building downloads from torrent files...")
 
@@ -27,6 +29,11 @@ func (c *Client) GetDownloads(torrents []*Torrent) ([]*Download, error) {
 			// Build a synthetic link identifier for matching: "torbox://{torrent_id}/{file_id}"
 			link := fmt.Sprintf("torbox://%d/%d", t.ID, f.ID)
 
+			// Use the requestdl endpoint with redirect=true as the download URL.
+			// When a media player hits this URL, TorBox redirects to the actual file.
+			downloadURL := fmt.Sprintf("%s/torrents/requestdl?token=%s&torrent_id=%d&file_id=%d&redirect=true",
+				c.Host, c.APIKey, t.ID, f.ID)
+
 			downloads = append(downloads, &Download{
 				TorrentID: t.ID,
 				FileID:    f.ID,
@@ -34,6 +41,7 @@ func (c *Client) GetDownloads(torrents []*Torrent) ([]*Download, error) {
 				MimeType:  f.MimeType,
 				Filesize:  f.Size,
 				Link:      link,
+				URL:       downloadURL,
 			})
 		}
 	}

--- a/pkg/torbox/provider.go
+++ b/pkg/torbox/provider.go
@@ -17,6 +17,9 @@ var _ provider.Provider = (*Provider)(nil)
 // Provider wraps the TorBox Client to implement the provider.Provider interface.
 type Provider struct {
 	*Client
+	// cachedTorrents stores the latest GetTorrents result to avoid duplicate API calls
+	// within the same sync cycle (GetDownloads needs the torrent list too).
+	cachedTorrents []*Torrent
 }
 
 // NewProvider creates a provider.Provider backed by TorBox.
@@ -30,23 +33,31 @@ func (p *Provider) Name() string {
 }
 
 // GetTorrents fetches torrents and returns them as provider types.
+// Caches the raw torrent list so GetDownloads() doesn't need a second API call.
 func (p *Provider) GetTorrents() ([]*provider.Torrent, []*provider.Torrent, error) {
 	downloaded, dead, err := p.Client.GetTorrents()
 	if err != nil {
 		return nil, nil, err
 	}
+	// Cache for GetDownloads() to reuse
+	p.cachedTorrents = downloaded
 	return convertTorrents(downloaded), convertTorrents(dead), nil
 }
 
 // GetDownloads fetches all completed torrent files as provider Downloads.
+// Reuses cached torrents from GetTorrents() if available.
 func (p *Provider) GetDownloads() ([]*provider.Download, error) {
-	// First get all completed torrents
-	downloaded, _, err := p.Client.GetTorrents()
-	if err != nil {
-		return nil, err
+	torrents := p.cachedTorrents
+	if torrents == nil {
+		// Fallback: fetch if GetTorrents() wasn't called first
+		var err error
+		torrents, _, err = p.Client.GetTorrents()
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	tbDownloads, err := p.Client.GetDownloads(downloaded)
+	tbDownloads, err := p.Client.GetDownloads(torrents)
 	if err != nil {
 		return nil, err
 	}
@@ -124,20 +135,7 @@ func (p *Provider) CheckLink(link string) error {
 
 // getTorrentByID fetches a single torrent by ID.
 func (p *Provider) getTorrentByID(torrentID int) (*Torrent, error) {
-	url := fmt.Sprintf("%s/torrents/mylist?id=%d", p.Client.Host, torrentID)
-	// Reuse the client's GetTorrents for a single ID fetch
-	// This is a simplified inline request
-	downloaded, _, err := p.Client.GetTorrents()
-	if err != nil {
-		return nil, err
-	}
-	for _, t := range downloaded {
-		if t.ID == torrentID {
-			return t, nil
-		}
-	}
-	_ = url // suppress unused warning — we'd use the targeted endpoint in a real optimization
-	return nil, fmt.Errorf("torrent %d not found", torrentID)
+	return p.Client.GetTorrentByID(fmt.Sprintf("%d", torrentID))
 }
 
 // parseTorBoxLink parses a synthetic TorBox link "torbox://{torrent_id}/{file_id}".

--- a/pkg/torbox/torrents.go
+++ b/pkg/torbox/torrents.go
@@ -123,41 +123,50 @@ func (c *Client) AddMagnet(hash string) (string, error) {
 	return id, nil
 }
 
-// SelectVideoFiles selects video files from a torrent.
-// TorBox doesn't have a file selection step like Real-Debrid — files are available immediately.
-// This returns the count of video files in the torrent.
-func (c *Client) SelectVideoFiles(torrentID string) (int, error) {
-	// Fetch torrent info to count video files
+// GetTorrentByID fetches a single torrent by ID.
+func (c *Client) GetTorrentByID(torrentID string) (*Torrent, error) {
 	url := fmt.Sprintf("%s/torrents/mylist?id=%s", c.Host, torrentID)
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("fetching torrent info: %w", err)
+		return nil, fmt.Errorf("fetching torrent info: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("reading response: %w", err)
+		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("API error: status %d", resp.StatusCode)
+		return nil, fmt.Errorf("API error: status %d", resp.StatusCode)
 	}
 
 	var apiResp APIResponse[*Torrent]
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return 0, fmt.Errorf("parsing torrent info: %w", err)
+		return nil, fmt.Errorf("parsing torrent info: %w", err)
 	}
 
 	if !apiResp.Success || apiResp.Data == nil {
-		return 0, fmt.Errorf("torrent not found: %s", torrentID)
+		return nil, fmt.Errorf("torrent not found: %s", torrentID)
+	}
+
+	return apiResp.Data, nil
+}
+
+// SelectVideoFiles selects video files from a torrent.
+// TorBox doesn't have a file selection step like Real-Debrid — files are available immediately.
+// This returns the count of video files in the torrent.
+func (c *Client) SelectVideoFiles(torrentID string) (int, error) {
+	torrent, err := c.GetTorrentByID(torrentID)
+	if err != nil {
+		return 0, err
 	}
 
 	count := 0
 	minSize := c.config.MinFileSizeBytes()
-	for _, f := range apiResp.Data.Files {
+	for _, f := range torrent.Files {
 		ext := strings.ToLower(filepath.Ext(f.Name))
 		if (ext == ".mkv" || ext == ".mp4") && f.Size >= minSize {
 			count++


### PR DESCRIPTION
## Summary

- Fix empty download URLs in TorBox STRM files by using the `requestdl` endpoint with `redirect=true`
- Extract `GetTorrentByID` method to avoid fetching all torrents for single lookups
- Cache torrent list between `GetTorrents`/`GetDownloads` calls to eliminate duplicate API calls

## Details

TorBox downloads had empty URLs because download links are requested per-file rather than pre-cached like Real-Debrid. The fix uses the `requestdl` redirect URL directly in STRM files — when a media player opens the `.strm`, TorBox redirects to the actual file. This also avoids expiry issues since the redirect is always fresh.

## Test plan

- [ ] Run `dry-run` with TorBox provider and verify STRM candidates have non-empty download URLs
- [ ] Run `run` and verify `.strm` files contain valid `requestdl` redirect URLs
- [ ] Verify media player (Infuse/Jellyfin) can play files via the redirect URLs

https://claude.ai/code/session_01KfL3w2dRYg8urbCDmb7hRp