### PR TITLE
fix: use float64 for TorBox availability field

### DIFF
--- a/pkg/torbox/types.go
+++ b/pkg/torbox/types.go
@@ -36,7 +36,7 @@ type Torrent struct {
 	DownloadFinished bool          `json:"download_finished"`
 	Files            []TorrentFile `json:"files"`
 	InactiveCheck    int           `json:"inactive_check"`
-	Availability     int           `json:"availability"`
+	Availability     float64       `json:"availability"`
 }
 
 // GetAddedAt parses the created_at timestamp.


### PR DESCRIPTION
## Summary
- TorBox API returns `availability` as a float (e.g. `1.869`), but the Go struct had it typed as `int`
- This caused JSON unmarshal errors, breaking every sync cycle
- Changed the field type from `int` to `float64` in `pkg/torbox/types.go`

Closes #5

https://claude.ai/code/session_01KfL3w2dRYg8urbCDmb7hRp